### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 django_maskurl
 ==============
-[![Build Status](https://travis-ci.org/RedXBeard/django_maskurl.svg?branch=master)](https://travis-ci.org/RedXBeard/django_maskurl) 
-[![Downloads](https://img.shields.io/pypi/dm/django-maskurl.svg
-[![Latest Version](https://img.shields.io/pypi/v/django-maskurl.svg
-[![Supported Python versions](https://img.shields.io/pypi/pyversions/django-maskurl.svg
-[![License](https://img.shields.io/pypi/l/django-maskurl.svg
+[![Build Status](https://travis-ci.org/RedXBeard/django_maskurl.svg?branch=master)](https://travis-ci.org/RedXBeard/django_maskurl)
+[![Latest Version](https://img.shields.io/pypi/v/django-maskurl.svg](https://pypi.python.org/pypi/django-maskurl/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/django-maskurl.svg](https://pypi.python.org/pypi/django-maskurl/)
+[![License](https://img.shields.io/pypi/l/django-maskurl.svg)](https://pypi.python.org/pypi/django-maskurl/)
 
 
 Masking url's on templates not to show exact path, hiding them all except get params.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 django_maskurl
 ==============
 [![Build Status](https://travis-ci.org/RedXBeard/django_maskurl.svg?branch=master)](https://travis-ci.org/RedXBeard/django_maskurl) 
-[![Downloads](https://pypip.in/download/django-maskurl/badge.svg?period=day)](https://pypi.python.org/pypi/django-maskurl/)
-[![Latest Version](https://pypip.in/version/django-maskurl/badge.svg)](https://pypi.python.org/pypi/django-maskurl/)
-[![Supported Python versions](https://pypip.in/py_versions/django-maskurl/badge.svg)](https://pypi.python.org/pypi/django-maskurl/)
-[![License](https://pypip.in/license/django-maskurl/badge.svg)](https://pypi.python.org/pypi/django-maskurl/)
+[![Downloads](https://img.shields.io/pypi/dm/django-maskurl.svg
+[![Latest Version](https://img.shields.io/pypi/v/django-maskurl.svg
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/django-maskurl.svg
+[![License](https://img.shields.io/pypi/l/django-maskurl.svg
 
 
 Masking url's on templates not to show exact path, hiding them all except get params.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 django_maskurl
 ==============
 [![Build Status](https://travis-ci.org/RedXBeard/django_maskurl.svg?branch=master)](https://travis-ci.org/RedXBeard/django_maskurl)
-[![Latest Version](https://img.shields.io/pypi/v/django-maskurl.svg](https://pypi.python.org/pypi/django-maskurl/)
-[![Supported Python versions](https://img.shields.io/pypi/pyversions/django-maskurl.svg](https://pypi.python.org/pypi/django-maskurl/)
+[![Latest Version](https://img.shields.io/pypi/v/django-maskurl.svg)](https://pypi.python.org/pypi/django-maskurl/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/django-maskurl.svg)](https://pypi.python.org/pypi/django-maskurl/)
 [![License](https://img.shields.io/pypi/l/django-maskurl.svg)](https://pypi.python.org/pypi/django-maskurl/)
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-maskurl))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-maskurl`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.